### PR TITLE
Transaction Routes Implementation

### DIFF
--- a/liquid-split-app/Ls-backend/src/index.js
+++ b/liquid-split-app/Ls-backend/src/index.js
@@ -6,8 +6,10 @@ import rateLimit from "express-rate-limit";
 import morgan from "morgan";
 import { PrismaClient } from "@prisma/client";
 
+
 import potRoutes from "./routes/pots.js";
 import authRoutes from "./routes/auth.js";
+import transactionsRoutes from "./routes/transactions.js";
 import { auth } from "./middleware/auth.js";
 
 dotenv.config();
@@ -68,8 +70,10 @@ app.use(morgan(process.env.NODE_ENV === "production" ? "combined" : "dev"));
 app.get("/health", (req, res) => res.send("💧 Ls-backend up and running!"));
 
 // ===== Routes =====
-app.use("/auth", authRoutes);       // public (register/login)
-app.use("/pots", auth, potRoutes);  // protected
+
+app.use("/auth", authRoutes);             // public (register/login)
+app.use("/pots", auth, potRoutes);        // protected
+app.use("/transactions", auth, transactionsRoutes); // protected
 
 // ===== 404 Handler =====
 app.use((req, res) => {

--- a/liquid-split-app/Ls-backend/src/routes/transactions.js
+++ b/liquid-split-app/Ls-backend/src/routes/transactions.js
@@ -1,0 +1,94 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+
+const router = express.Router();
+const prisma = new PrismaClient();
+const approvals = {}; // in-memory approvals for proposals
+
+// Create a transaction proposal
+router.post("/propose", async (req, res, next) => {
+  try {
+    const { potId, amount, description } = req.body;
+    if (!potId || !amount) return res.status(400).json({ error: "potId and amount required" });
+    const proposal = await prisma.transaction.create({
+      data: {
+        potId: Number(potId),
+        amount: Number(amount),
+        description: description || null,
+        status: "PENDING",
+      },
+    });
+    approvals[proposal.id] = {};
+    res.json(proposal);
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Approve a transaction proposal
+router.post("/approve/:id", async (req, res, next) => {
+  try {
+    const txId = Number(req.params.id);
+    const { userId } = req.body;
+    if (!userId) return res.status(400).json({ error: "userId required" });
+    if (!approvals[txId]) approvals[txId] = {};
+    approvals[txId][userId] = true;
+    res.json({ message: `User ${userId} approved transaction ${txId}` });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Execute a transaction (split payment)
+router.post("/execute/:id", async (req, res, next) => {
+  try {
+    const txId = Number(req.params.id);
+    const tx = await prisma.transaction.findUnique({
+      where: { id: txId },
+      include: { pot: { include: { members: { include: { user: true } } } } },
+    });
+    if (!tx) return res.status(404).json({ error: "Transaction not found" });
+    if (tx.status !== "PENDING") return res.status(400).json({ error: "Transaction already executed or cancelled" });
+    const potMembers = tx.pot.members;
+    if (!potMembers.length) return res.status(400).json({ error: "No members in this pot" });
+    const txApproval = approvals[txId] || {};
+    const allApproved = potMembers.every((m) => txApproval[m.userId]);
+    if (!allApproved) return res.status(400).json({ error: "Not all members have approved" });
+    // Split payment
+    await prisma.$transaction([
+      ...potMembers.map((m) =>
+        prisma.user.update({
+          where: { id: m.userId },
+          data: { balance: m.user.balance - tx.amount * m.share },
+        })
+      ),
+      prisma.pot.update({
+        where: { id: tx.potId },
+        data: { totalAmount: { increment: tx.amount } },
+      }),
+      prisma.transaction.update({
+        where: { id: txId },
+        data: { status: "EXECUTED" },
+      }),
+    ]);
+    delete approvals[txId];
+    res.json({ message: "Transaction executed successfully" });
+  } catch (err) {
+    next(err);
+  }
+});
+
+// Fetch transaction history
+router.get("/", async (req, res, next) => {
+  try {
+    const txs = await prisma.transaction.findMany({
+      orderBy: { createdAt: "desc" },
+      include: { pot: true },
+    });
+    res.json(txs);
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;


### PR DESCRIPTION
This pull request introduces a new transaction management feature to the backend, enabling users to propose, approve, execute, and fetch transaction histories related to "pots." The main changes include the addition of a new `transactions` route, integration of this route into the main app, and the implementation of core transaction proposal and approval logic.

**Transaction management feature:**

* Added a new `transactions` route (`transactions.js`) that allows users to:
  - Propose new transactions for a pot.
  - Approve pending transaction proposals.
  - Execute transactions (splitting payments among pot members after all approvals).
  - Fetch transaction history.

* Integrated the `transactions` route into the main application and protected it with authentication middleware, ensuring only authorized users can access transaction endpoints. [[1]](diffhunk://#diff-69d8b922b56c1ecd135efc44972be1fa4d4919cd040f73dae34214ac87407949R9-R12) [[2]](diffhunk://#diff-69d8b922b56c1ecd135efc44972be1fa4d4919cd040f73dae34214ac87407949R73-R76)